### PR TITLE
Let Crops Grow On SSP Starter Islands

### DIFF
--- a/config/skyblockbuilder/common-config.json5
+++ b/config/skyblockbuilder/common-config.json5
@@ -60,19 +60,11 @@
     //    damage            = Attacking others, or getting attacked
     //    healing           = Getting healed and saturated on spawn
     "spawnProtectionEvents": [
-      "interact_entities",
-      "interact_blocks",
       "mob_griefing",
-      "explosions",
-      "crop_grow",
-      "mobs_spawn",
-      "mobs_spawn_egg",
-      "damage",
-      "healing"
     ],
     
     // The radius of chunks where to apply spawn protection. In this area, only op players can avoid this.
-    "spawnProtectionRadius": 5,
+    "spawnProtectionRadius": 2,
     
     "Height": {
     


### PR DESCRIPTION
Fixing no crop issue by allowing more events at spawn. 

Also,  shrink spawn chunk radius to 2.

This bjorks SMP spawn areas, but the pack doesn't really have a setup for SMP anyways right now, I think?